### PR TITLE
Adds `--HEAD` option and SPDX license identifier

### DIFF
--- a/Formula/ion-cli.rb
+++ b/Formula/ion-cli.rb
@@ -4,9 +4,16 @@
 class IonCli < Formula
   desc "Command line tools for working with the Ion data format."
   homepage "https://github.com/amzn/ion-cli"
+  license "Apache-2.0"
+
+  # Allows installing unreleased changes with the --HEAD flag
+  head "https://github.com/amazon-ion/ion-cli.git", branch: "master"
+
+  # Latest release
   url "https://github.com/amzn/ion-cli/archive/refs/tags/v0.5.0.tar.gz"
   sha256 "54c5a4bec9c833f273b15c101e55ec8affa0c672324c36e2b219e5b9f80c7744"
   version "0.5.0"
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

* Adds license info to the formula
* Adds support for installing unreleased changes from `ion-cli` with the `--HEAD` option.
("If formula defines it, install the HEAD version, aka. main, trunk, unstable, master." [source](https://docs.brew.sh/Manpage#install-options-formulacask-))

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
