### PR TITLE
Support all features of `ion-cli` with `HEAD`

### DIFF
--- a/Formula/ion-cli.rb
+++ b/Formula/ion-cli.rb
@@ -17,18 +17,30 @@ class IonCli < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build", "--release", "--bin", "ion"
+    if build.head?
+      system "cargo", "build", "--all-features" , "--release", "--bin", "ion"
+    else
+      system "cargo", "build", "--release", "--bin", "ion"
+    end
     bin.install "target/release/ion"
   end
 
   test do
-    # Make sure that `ion --version` outputs the expected version number
-    assert_match("ion #{self.version}", shell_output("ion --version"))
-    # Make a simple Ion file with a few values in it
-    (testpath/"example.ion").write "foo true 5. null [1, 2, 3]"
-    # Convert the file to binary Ion and assert that the exit status is 0 (successful)
-    shell_output("ion dump --format binary -o ./example.10n ./example.ion")
-    # Convert the binary Ion file back to text and look for the resolved symbol text `foo`
-    assert_match("foo", shell_output("ion dump --format pretty ./example.10n"))
+    if build.head?
+      # Make sure that this version is pointing to HEAD
+      assert_match("HEAD", "#{self.version}")
+      # Head should support all features of `ion-cli`
+      # Verify if `generate` subcommand exist on `beta` (`generate` is an experimental feature under `ion-cli`)
+      assert_match("generate", shell_output("ion beta generate --help"))
+    else
+      # Make sure that `ion --version` outputs the expected version number
+      assert_match("ion #{self.version}", shell_output("ion --version"))
+      # Make a simple Ion file with a few values in it
+      (testpath/"example.ion").write "foo true 5. null [1, 2, 3]"
+      # Convert the file to binary Ion and assert that the exit status is 0 (successful)
+      shell_output("ion dump --format binary -o ./example.10n ./example.ion")
+      # Convert the binary Ion file back to text and look for the resolved symbol text `foo`
+      assert_match("foo", shell_output("ion dump --format pretty ./example.10n"))
+    end
   end
 end


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR adds support for all features of `ion-cli` with `HEAD`.

### List of changes:
* Modified install method to include `--all-feature` when `build.head`
is present
* Added tests for `build.head`

### Test 

Tested with `brew test ./Formula/ion-cli.rb` to run tests on formula pointing to head.


----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
