### PR TITLE
Removes Formula tests for unstable commands

### DIFF
--- a/Formula/ion-cli.rb
+++ b/Formula/ion-cli.rb
@@ -26,12 +26,11 @@ class IonCli < Formula
   end
 
   test do
-      # Make a simple Ion file with a few values in it
-      (testpath/"example.ion").write "foo true 5. null [1, 2, 3]"
-      # Convert the file to binary Ion and assert that the exit status is 0 (successful)
-      shell_output("ion cat --format binary -o ./example.10n ./example.ion")
-      # Convert the binary Ion file back to text and look for the resolved symbol text `foo`
-      assert_match("foo", shell_output("ion cat --format pretty ./example.10n"))
-    end
+    # Make a simple Ion file with a few values in it
+    (testpath/"example.ion").write "foo true 5. null [1, 2, 3]"
+    # Convert the file to binary Ion and assert that the exit status is 0 (successful)
+    shell_output("ion cat --format binary -o ./example.10n ./example.ion")
+    # Convert the binary Ion file back to text and look for the resolved symbol text `foo`
+    assert_match("foo", shell_output("ion cat --format pretty ./example.10n"))
   end
 end

--- a/Formula/ion-cli.rb
+++ b/Formula/ion-cli.rb
@@ -17,11 +17,7 @@ class IonCli < Formula
   depends_on "rust" => :build
 
   def install
-    if build.head?
-      system "cargo", "build", "--all-features" , "--release", "--bin", "ion"
-    else
-      system "cargo", "build", "--release", "--bin", "ion"
-    end
+    system "cargo", "build", "--release", "--bin", "ion"
     bin.install "target/release/ion"
   end
 

--- a/Formula/ion-cli.rb
+++ b/Formula/ion-cli.rb
@@ -3,7 +3,7 @@
 # * https://rubydoc.brew.sh/Formula
 class IonCli < Formula
   desc "Command line tools for working with the Ion data format."
-  homepage "https://github.com/amzn/ion-cli"
+  homepage "https://github.com/amazon-ion/ion-cli"
   license "Apache-2.0"
 
   # Allows installing unreleased changes with the --HEAD flag
@@ -26,25 +26,12 @@ class IonCli < Formula
   end
 
   test do
-    if build.head?
-      # Make sure that this version is pointing to HEAD
-      assert_match("HEAD", "#{self.version}")
-      # Head should support all features of `ion-cli`
-      # Verify if `generate` subcommand exist on `beta` (`generate` is an experimental feature under `ion-cli`)
-      assert_match("generate", shell_output("ion beta generate --help"))
-      # Make an Ion schema file with simple type definition
-      (testpath/"example.isl").write "type::{ name: foo, type: int }"
-      # Generate code based on above schema file and assert that the exit status is 0 (successful)
-      shell_output("ion beta generate --directory #{testpath} --schema example.isl --language java --namespace org.example")
-    else
-      # Make sure that `ion --version` outputs the expected version number
-      assert_match("ion #{self.version}", shell_output("ion --version"))
       # Make a simple Ion file with a few values in it
       (testpath/"example.ion").write "foo true 5. null [1, 2, 3]"
       # Convert the file to binary Ion and assert that the exit status is 0 (successful)
-      shell_output("ion dump --format binary -o ./example.10n ./example.ion")
+      shell_output("ion cat --format binary -o ./example.10n ./example.ion")
       # Convert the binary Ion file back to text and look for the resolved symbol text `foo`
-      assert_match("foo", shell_output("ion dump --format pretty ./example.10n"))
+      assert_match("foo", shell_output("ion cat --format pretty ./example.10n"))
     end
   end
 end


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

I don't think we should be running Formula tests that test unstable commands. That's just asking for something to break.

I also think that we should probably remove the cargo feature flag from the `generate` command and just have it live behind the `-X` flag. It seems unnecessarily complicated to have both. However, I'm not intending to address that in this PR. I'm just trying to clean up the formula.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
