### PR TITLE
Update workflow to open a PR instead of directly pushing to main

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -18,6 +18,9 @@ jobs:
     # Don't run the cron schedule in forks
     if: github.repository == 'amazon-ion/homebrew-ion-cli' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - shell: bash
@@ -47,9 +50,13 @@ jobs:
                 -e 's/  sha256 .*/  sha256 "'"$sha"'"/g' \
                 -e 's/  version .*/  version "'"$version"'"/g' Formula/ion-cli.rb
           
-            git config user.name github-actions
-            git config user.email github-actions@github.com
+            # TODO: Use the bot token for pushing so that the PR can be auto-approved and merged.
+            git config user.name amazon-ion-bot
+            git config user.email ion-team+amazon-ion-bot@amazon.com
+            git checkout -b "formula-update-$version"
             git add -u
             git commit -m "Update ion-cli formula to $tag"
-            git push
+            # In case this is a re-run, we're going to force push
+            git push --force --set-upstream origin "formula-update-$version"
+            gh pr create --fill
           fi


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

Updates the auto-update workflow to open a PR since there are permission restrictions and branch protection rules preventing the workflow from pushing directly to `main`.

Now, it will push to a branch named `formula-update-$version` (e.g. `formula-update-0.9.1`) and then open a PR.

See example PR here: https://github.com/popematt/homebrew-ion-cli/pull/2

In future, we can work using the Amazon Ion Bot token for opening the PR and then we should be able to auto-approve/merge the PR, or it might be possible to allow the Amazon Ion Bot to bypass branch protection rules.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
